### PR TITLE
updated detector to enable different models to be used

### DIFF
--- a/ros/src/tl_detector/launch/tl_detector.launch
+++ b/ros/src/tl_detector/launch/tl_detector.launch
@@ -2,4 +2,5 @@
 <launch>
     <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
     <param name="bbooth_model_path" value="$(find styx)../../../data/frozen_inference_graph.pb" />
+    <param name="bbooth_model_site" value="$(find styx)../../../data/frozen_inference_graph.pb" />
 </launch>

--- a/ros/src/tl_detector/launch/tl_detector_site.launch
+++ b/ros/src/tl_detector/launch/tl_detector_site.launch
@@ -3,4 +3,5 @@
     <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
     <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" output="screen" cwd="node"/>
     <param name="bbooth_model_path" value="$(find styx)../../../data/frozen_inference_graph.pb" />
+    <param name="bbooth_model_site" value="$(find styx)../../../data/frozen_inference_graph.pb" />
 </launch>


### PR DESCRIPTION
This uses the is_site config parameter in the config.yaml file in the tl_detector. The current version adds a second model path to both launch files in the /launch section of the tl_detector node. This will need updating to specify the second model name once we have one.